### PR TITLE
add soca to list of jcsda repos to sync

### DIFF
--- a/.github/workflows/sync_jcsda.yaml
+++ b/.github/workflows/sync_jcsda.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         organization: ['jcsda']
-        repository: ['oops', 'saber', 'ioda', 'ufo', 'fv3-jedi', 'fv3-bundle']
+        repository: ['oops', 'saber', 'ioda', 'ufo', 'fv3-jedi', 'fv3-bundle', 'soca']
         branch: ['develop']
 
     steps:


### PR DESCRIPTION
This PR adds `soca` to the list of forked NOAA-EMC repos to routinely sync with JCSDA.

Resolves #2