### PR TITLE
Merge develop into dev/emc in SOCA fork

### DIFF
--- a/.github/workflows/merge_devemc.yaml
+++ b/.github/workflows/merge_devemc.yaml
@@ -1,0 +1,44 @@
+name: Merge develop into dev/emc
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'  # every 15 minutes
+  workflow_dispatch:        # allows manual trigger
+
+jobs:
+  merge_branches:
+    name: Merge develop -> dev/emc
+    runs-on: ubuntu-latest
+    env:
+      WORKFLOW_USER: 'emcbot'
+      WORKFLOW_EMAIL: 'emcbot@users.noreply.github.com'
+      WORKFLOW_TOKEN: ${{ secrets.JEDI_SYNC_TOKEN }}
+      FORK: 'noaa-emc'
+    strategy:
+      matrix:
+        repository: ['soca']
+
+    steps:
+    - name: Checkout dev/emc
+      uses: actions/checkout@v2
+      with:
+        repository: noaa-emc/${{ matrix.repository }}
+        ref: dev/emc
+        token: ${{ secrets.JEDI_SYNC_TOKEN }}
+        path: ${{ matrix.repository }}-devemc
+
+    - name: Configure Git
+      run: |
+        git config --global user.name "emcbot"
+        git config --global user.email "emcbot@users.noreply.github.com"
+
+    - name: Fetch and merge develop
+      run: |
+        cd ${{ matrix.repository }}-devemc
+        git fetch origin develop
+        git merge origin/develop --no-edit || true
+
+    - name: Push changes to dev/emc
+      run: |
+        cd ${{ matrix.repository }}-devemc
+        git push origin HEAD:dev/emc

--- a/.github/workflows/merge_devemc.yaml
+++ b/.github/workflows/merge_devemc.yaml
@@ -12,7 +12,7 @@ jobs:
     env:
       WORKFLOW_USER: 'emcbot'
       WORKFLOW_EMAIL: 'emcbot@users.noreply.github.com'
-      WORKFLOW_TOKEN: ${{ secrets.JEDI_SYNC_TOKEN }}
+      WORKFLOW_TOKEN: ${{ secrets.UFS_SYNC_TOKEN }}
       FORK: 'noaa-emc'
     strategy:
       matrix:

--- a/.github/workflows/sync_jcsda.yaml
+++ b/.github/workflows/sync_jcsda.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         organization: ['jcsda']
-        repository: ['oops', 'saber', 'ioda', 'ufo', 'fv3-jedi', 'fv3-bundle']
+        repository: ['oops', 'saber', 'ioda', 'ufo', 'fv3-jedi', 'fv3-bundle', 'soca']
         branch: ['develop']
 
     steps:


### PR DESCRIPTION
This PR add a YAML to drive a GitHub actions workflow to merge the develop branch into dev/emc branch in the NOAA-EMC SOCA fork or a periodic basis. It also adds SOCA to the list of forked NOAA-EMC repos to routinely sync with JCSDA.

Resolves [#2](https://github.com/NOAA-EMC/emcsyncbot/issues/2)